### PR TITLE
Add github actions to sync `docs/` from gitlab nomad-FAIR repo

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -26,10 +26,31 @@ jobs:
       run: |
         rsync -av --delete gitlab-temp/docs/ docs/
 
-    - name: Commit and push changes (if any)
+    - name: Check for Changes
+      id: check-changes
       run: |
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add docs/
-        git commit -m "Sync docs from GitLab (sparse + rsync)" || echo "No changes to commit"
-        git push origin main
+        if [ -z "$(git status --porcelain)" ]; then
+          echo "changed=false" >> $GITHUB_OUTPUT
+        else
+          echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+
+    # - name: Commit and push changes (if any)
+    #   if: steps.check-changes.outputs.changed == 'true'
+    #   run: |
+    #     git config user.name "github-actions[bot]"
+    #     git config user.email "github-actions[bot]@users.noreply.github.com"
+    #     git add docs/
+    #     git commit -m "Sync docs from GitLab (sparse + rsync)" || echo "No changes to commit"
+    #     git push origin main
+
+    - name: Create Pull Request
+      if: ${{ steps.check-changes.outputs.changed == 'true' }}
+      uses: peter-evans/create-pull-request@v5
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Update docs"
+        title: "Update docs"
+        body: "This pull request updates docs."
+        branch: update-docs
+        base: main

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -1,0 +1,35 @@
+name: Sync GitLab NOMAD-FAIR Docs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout GitHub repo (main branch)
+      uses: actions/checkout@v4
+
+    - name: Sparse-checkout only 'docs/' from GitLab repo
+      run: |
+        GITLAB_REPO="https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git"
+
+        # Clone the repo with sparse-checkout to only get 'docs/'
+        git clone --filter=blob:none --no-checkout --branch develop "$GITLAB_REPO" gitlab-temp
+        cd gitlab-temp
+        git sparse-checkout init --cone
+        git sparse-checkout set docs
+        git checkout
+
+    - name: Rsync 'docs/' into current repo
+      run: |
+        rsync -av --delete gitlab-temp/docs/ docs/
+
+    - name: Commit and push changes (if any)
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+        git add docs/
+        git commit -m "Sync docs from GitLab (sparse + rsync)" || echo "No changes to commit"
+        git push origin main

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -46,7 +46,7 @@ jobs:
 
     - name: Create Pull Request
       if: ${{ steps.check-changes.outputs.changed == 'true' }}
-      uses: peter-evans/create-pull-request@v5
+      uses: peter-evans/create-pull-request@v7
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         commit-message: "Update docs"

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -35,15 +35,6 @@ jobs:
           echo "changed=true" >> $GITHUB_OUTPUT
         fi
 
-    # - name: Commit and push changes (if any)
-    #   if: steps.check-changes.outputs.changed == 'true'
-    #   run: |
-    #     git config user.name "github-actions[bot]"
-    #     git config user.email "github-actions[bot]@users.noreply.github.com"
-    #     git add docs/
-    #     git commit -m "Sync docs from GitLab (sparse + rsync)" || echo "No changes to commit"
-    #     git push origin main
-
     - name: Create Pull Request
       if: ${{ steps.check-changes.outputs.changed == 'true' }}
       uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
Add github actions to sync `docs/` from gitlab nomad-FAIR repo

TODO:
- [ ] there're a few commits directly to the `nomad-docs` repo, should not be overwritten during rsync

