### PR TITLE
Fix code guideline references

### DIFF
--- a/docs/reference/code_guidelines.md
+++ b/docs/reference/code_guidelines.md
@@ -172,7 +172,7 @@ either the whole thing or just some properties of this entities.
   purposes.
 
 - Calculation `handle` or `handle_id` are created based on those `pid`.
-  To create hashes we use :py:func:`nomad.utils.hash`.
+  To create hashes we use `nomad.utils.hash`.
 
 ## Logging
 
@@ -194,7 +194,7 @@ There are three important prerequisites to understand about nomad-FAIRDI's loggi
 
 Please follow the following rules when logging:
 
-- If a logger is not already provided, only use :py:func:`nomad.utils.get_logger` to
+- If a logger is not already provided, only use `nomad.utils.get_logger` to
   acquire a new logger. Never use the built-in logging directly. These loggers work like
   the system loggers, but allow you to pass keyword arguments with additional context
   data. See also the [structlog docs](https://structlog.readthedocs.io/en/stable/){:target="_blank"}.

--- a/docs/reference/code_guidelines.md
+++ b/docs/reference/code_guidelines.md
@@ -65,10 +65,8 @@ components and their props.
 
 For all functionality that is exposed to clients (APIs, CLI, schema base classes and
 annotations, UI functionality), you must consider to add explanations, tutorials, and
-examples to the documentation system (i.e. the `docs` folder). This is built with
-[mkdocs](https://www.mkdocs.org/){:target="_blank"} and published as part of each NOMAD installation.
-Also mind `nomad/mkdocs.py` and `mkdocs.yaml` and have a look at used plugins and extra
-functions, e.g. this includes generation of Markdown from `examples` or Pydantic models.
+examples to [the documentation system](https://github.com/FAIRmat-NFDI/nomad-docs){:target="_blank"}. This is built with
+[mkdocs](https://www.mkdocs.org/){:target="_blank"} and published as part of each NOMAD installation. Additionally, you can refer to the `src/nomad_docs` folder to see how the documentation is generated, and to the `mkdocs.yaml` file to understand its structure. 
 
 To document Python functions and classes, use Google
 [docstrings](https://github.com/NilsJPWerner/autoDocstring/blob/HEAD/docs/google.md){:target="_blank"}.


### PR DESCRIPTION
This PR updates a reference to a previous version of the docs repository and fixes a typo issued caused by ":py:" symbol when the markdown is rendered. 