### PR TITLE
Fix TODOs in markdownlint config: require first level headers, require alternate text for images

### DIFF
--- a/.github/workflows/configs/nomad.markdownlint.jsonc
+++ b/.github/workflows/configs/nomad.markdownlint.jsonc
@@ -29,7 +29,7 @@
     // TODO: we should probably add more NOMAD-specific rules
     "MD044": { "names": [
         "GitHub", "github.com", "github.io", "macOS", "Linux",
-        "nomad", "NOMAD", "FAIR", "fair", "JupyterHub", "jupyterhub"]
+        "nomad", "NOMAD", "FAIRmat", "fairmat", "FAIR", "fair", "JupyterHub", "jupyterhub"]
     },
     // MD046 - Code block style
     // NOTE: we have some custom collapsible text box marked by `???`

--- a/.github/workflows/configs/nomad.markdownlint.jsonc
+++ b/.github/workflows/configs/nomad.markdownlint.jsonc
@@ -1,6 +1,6 @@
 // https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
 {
-    // Set rules to enabled by default
+    // Enable rules by default
     "default": true,
 
     // MD004 - Unordered list style
@@ -11,41 +11,38 @@
     // MD009 - Trailing spaces
     "MD009": { "strict": true },
     // MD012 - Multiple consecutive blank lines
-    "MD012": {"maximum": 1},
+    "MD012": { "maximum": 1 },
     // MD013 - Line length
-    // IDEs would auto-wrap long lines
+    // IDEs would auto soft-wrap long lines
     "MD013": false,
     // MD026 - Trailing punctuation in heading
-    "MD026": {"punctuation": ".,;:。，；："},
+    "MD026": { "punctuation": ".,;:。，；：" },
     // MD033 - Inline HTML
     // NOTE: some inline HTML might be needed?
     "MD033": false,
     // MD035 - Horizontal rule style
-    "MD035": {"style": "---"},
+    "MD035": { "style": "---" },
     // MD036 - Emphasis used instead of a heading
     // NOTE: looks like some are intended as emphasis
     "MD036": false,
-    // MD041 - First line in a file should be a top-level heading
-    // TODO: enable this but some files are missing top headers
-    "MD041": false,
     // MD044 - Proper names should have the correct capitalization
     // TODO: we should probably add more NOMAD-specific rules
-    "MD044": {"names": ["GitHub", "github.com", "github.io", "macOS", "Linux", "nomad", "NOMAD", "JupyterHub", "jupyterhub"]},
-    // MD045 - Images should have alternate text (alt text)
-    // TODO: fix these
-    "MD045": false,
+    "MD044": { "names": [
+        "GitHub", "github.com", "github.io", "macOS", "Linux",
+        "nomad", "NOMAD", "FAIR", "fair", "JupyterHub", "jupyterhub"]
+    },
     // MD046 - Code block style
-    // NOTE: we have some custom folded text marked by `???`
+    // NOTE: we have some custom collapsible text box marked by `???`
     "MD046": false,
     // MD048 - Code fence style
-    "MD048": {"style": "backtick"},
+    "MD048": { "style": "backtick" },
     // MD049 - Emphasis style (Bold, Italic or both)
     // see: https://www.markdownguide.org/basic-syntax/#emphasis
-    "MD049": {"style": "asterisk"},
+    "MD049": { "style": "asterisk" },
     // MD050 - Strong style (Bold)
-    "MD050": {"style": "asterisk"},
+    "MD050": { "style": "asterisk" },
     // MD055 - Table pipe style
-    "MD055": {"style": "leading_and_trailing"},
+    "MD055": { "style": "leading_and_trailing" },
     // MD059 - Link text should be descriptive
     "MD059": false
 }

--- a/docs/aitoolkit.md
+++ b/docs/aitoolkit.md
@@ -1,1 +1,3 @@
+# Work in progress
+
 go here ..

--- a/docs/explanation/basics.md
+++ b/docs/explanation/basics.md
@@ -1,3 +1,4 @@
+# From files to data
 
 NOMAD is based on a *bottom-up* approach to data management. Instead of only supporting data in a specific
 predefined format, we process files to extract data from an extendable variety of data formats.

--- a/docs/explanation/data.md
+++ b/docs/explanation/data.md
@@ -1,3 +1,5 @@
+# Data structure
+
 NOMAD structures data into **sections**, where each section can contain data and more sections.
 This allows to browse complex data like you would browse files and directories on your computer.
 Each section follows a **definition** and all the contained data and subsection have a

--- a/docs/explanation/oasis.md
+++ b/docs/explanation/oasis.md
@@ -1,3 +1,5 @@
+# Federation and Oasis
+
 ## Why a federated data infrastructure?
 
 There are several benefits for using multiple NOMAD installations:

--- a/docs/howto/customization/tabular.md
+++ b/docs/howto/customization/tabular.md
@@ -7,7 +7,7 @@ Refer to the [Reference guide](../../reference/annotations.md) for the full list
 NOMAD and `Excel` support multiple-sheets data manipulations and imports. Each quantity in the schema will be annotated with a source path composed by sheet name and column header. The path to be used with the tabular data displayed below would be `Sheet1/My header 1` and it would be placed it the `tabular` annotation, see [schema annotations](../../tutorial/custom.md#to-be-an-entry-or-not-to-be-an-entry).
 
 <p align="center" width="100%">
-    <img width="30%" src="images/2col.png">
+    <img width="30%" src="images/2col.png" alt="single-sheet Excel file with two columns">
 </p>
 
 In the case there is only one sheet in the Excel file, or when using a `.csv` file that is a single-sheet format, the sheet name is not required in the path.
@@ -16,18 +16,18 @@ The data sheets can be stored in one or more files depending on the user needs. 
 
 1. Columns:
 
-    each column contains an array of cells that we want to parse into one quantity. Example: time and temperature arrays to be plotted as x and y.
+    Each column contains an array of cells that we want to parse into one quantity. Example: time and temperature arrays to be plotted as x and y.
 
     <p align="center" width="100%">
-        <img width="30%" src="images/columns.png">
+        <img width="30%" src="images/columns.png" alt="Each column for an array of data to parse">
     </p>
 
 2. Rows:
 
-    each row contains a set of cells that we want to parse into a section, i. e. a set of quantities. Example: an inventory tabular data file (for substrates, precursors, or more) where each column represents a property and each row corresponds to one unit stored in the inventory.
+    Each row contains a set of cells that we want to parse into a section, i. e. a set of quantities. Example: an inventory tabular data file (for substrates, precursors, or more) where each column represents a property and each row corresponds to one unit stored in the inventory.
 
     <p align="center" width="100%">
-        <img width="30%" src="images/rows.png">
+        <img width="30%" src="images/rows.png" alt="Each row for a section">
     </p>
 
 3. Rows with repeated columns:
@@ -35,13 +35,13 @@ The data sheets can be stored in one or more files depending on the user needs. 
     In addition to the mode 2), whenever the parser detects the presence of multiple columns (or multiple sets of columns) with same headers, these are taken as multiple instances of a subsection. More explanations will be delivered when showing the schema for such a structure. Example: a crystal growth process where each row is a step of the crystal growth and the repeated columns describe the "precursor materials", that can be more than one during such processes and they are described by the same "precursor material" section.
 
     <p align="center" width="100%">
-        <img width="45%" src="images/rows_subsection.png">
+        <img width="45%" src="images/rows_subsection.png" alt="Multiple columns with repeated headers">
     </p>
 
 Furthermore, we can insert comments before our data, we can use a special character to mark one or more rows as comment rows. The special character is annotated within the schema in the `tabular` annotation, see [schema annotations](../../tutorial/custom.md#to-be-an-entry-or-not-to-be-an-entry):
 
 <p align="center" width="100%">
-    <img width="30%" src="images/2col_notes.png">
+    <img width="30%" src="images/2col_notes.png" alt="sheet with annotation before header">
 </p>
 
 ## Inheriting the TableData base section
@@ -83,7 +83,7 @@ In this section eight examples will be presented, containing all the features av
 ### 1. Column mode, current Entry, parse to root
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-1.png">
+    <img width="100%" src="./images/tabular-1.png" alt="Parse each column to an Entry">
 </p>
 
 The first case gives rise to the simplest data archive file. Here the tabular data file is parsed by columns, directly within the Entry where the `TableData` is inherited and filling the quantities in the root level of the schema (see dedicated how-to to learn [how to inherit tabular parser in your schema](tabular.md#inheriting-the-tabledata-base-section)).
@@ -100,7 +100,7 @@ The first case gives rise to the simplest data archive file. Here the tabular da
 ### 2. Column mode, current Entry, parse to my path
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-2.png">
+    <img width="100%" src="./images/tabular-2.png" alt="Parse each column to custom path">
 </p>
 
 The parsing mode presented here only differs from the previous for the `sections` annotations. In this case the section that we want to fill with tabular data can be nested arbitrarily deep in the schema and the `sections` annotation must be filled with a forward slash path to the desired section, e. g. `my_sub_section/my_sub_sub_section`.
@@ -118,7 +118,7 @@ The parsing mode presented here only differs from the previous for the `sections
 ### 3. Row mode, current Entry, parse to my path
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-3.png">
+    <img width="100%" src="./images/tabular-3.png" alt="Parse each row to one instance">
 </p>
 
 The current is the first example of parsing in row mode. This means that every row of the excel file while be placed in one instance of the section that is defined in `sections`. This section must be decorated with `repeats: true` annotation, it will allow to generate multiple instances that will be appended in a list with sequential numbers. Instead of sequential numbers, the list can show specific names if `label_quantity` annotation is appended to the repeated section. This annotation is included in the how-to example. The section is written separately in the schema and it does not need the `EntryData` inheritance because the instances will be grafted directly in the current Entry. As explained [below](#91-row-mode-current-entry-parse-to-root), it is not possible for `row` and `current_entry` to parse directly in the root because we need to create multiple instances of the selected subsection and organize them in a list.
@@ -138,7 +138,7 @@ The current is the first example of parsing in row mode. This means that every r
 ### 4. Column mode, single new Entry, parse to my path
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-4.png">
+    <img width="100%" src="./images/tabular-4.png" alt="Parse column-wise to new Entry">
 </p>
 
 One more step of complexity is added here: the parsing is not performed in the current Entry, but a new Entry it automatically generated and filled.
@@ -158,7 +158,7 @@ This structure foresees a parent Entry where we collect one or more tabular data
 ### 5. Row mode, single new Entry, parse to my path
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-5.png">
+    <img width="100%" src="./images/tabular-5.png" alt="Parse row-wise to new Entry">
 </p>
 
 Example analogous to the previous, where the new created Entry contains now a repeated subsection with a list of instances made from each line of the tabular data file, as show in the [Row mode, current Entry, parse to my path](#3-row-mode-current-entry-parse-to-my-path) case.
@@ -179,7 +179,7 @@ Example analogous to the previous, where the new created Entry contains now a re
 ### 6. Row mode, multiple new entries, parse to root
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-6.png">
+    <img width="100%" src="./images/tabular-6.png" alt="Parse row-wise to multiple new entries in root">
 </p>
 
 The last feature available for tabular parser is now introduced: `multiple_new_entries`. It is only meaningful for `row` mode because each row of the tabular data file will be placed in a new Entry that is an instance of a class defined in the schema, this would not make sense for columns, though, as they usually need to be parsed all together in one class of the schema, for example the "timestamp" and "temperature" columns in a spreadsheet file would need to lie in the same class as they belong to the same part of experiment.
@@ -200,7 +200,7 @@ A further comment is needed to explain the combination of this feature with `roo
 ### 7. Row mode, multiple new entries, parse to my path
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-7.png">
+    <img width="100%" src="./images/tabular-7.png" alt="Parse row-wise to multiple new entries to custom path">
 </p>
 
 As anticipated in the previous example, `row` mode in connection to `multiple_new_entries` will produce a manyfold of instances of a specific class, each of them being a new Entry. In the present case, each instance will also automatically be placed in a `ReferenceEditQuantity` quantity lying in a subsection defined within the parent Entry, coloured in plum in the following example image.
@@ -221,7 +221,7 @@ As anticipated in the previous example, `row` mode in connection to `multiple_ne
 ### 8. The Sub-Subsection nesting schema
 
 <p align="center" width="100%">
-    <img width="100%" src="./images/tabular-8.png">
+    <img width="100%" src="./images/tabular-8.png" alt="Parse columns with the same name to nested subsection">
 </p>
 
 If the tabular data file contains multiple columns with exact same name, there is a way to parse them using `row` mode. As explained in previous examples, this mode creates an instance of a subsection of the schema for each row of the file. Whenever column with same name are found they are interpreted as multiple instances of a sub-subsection nested inside the subsection. To build a schema with such a feature it is enough to have two nested classes, each of them bearing a `repeats: true` annotation. This structure can be applied to each and every of the cases above with `row` mode parsing.

--- a/docs/howto/develop/normalizing.md
+++ b/docs/howto/develop/normalizing.md
@@ -1,3 +1,5 @@
+# Write a normalizer
+
 ## The `update_entry` method
 
 The root context, which is available from the `.m_context` of a `EntryArchive`, which could be accessed via `section.m_root().m_context` if `section` is attached to a `EntryArchive`, provides the functionality to update/create child entries on-the-fly and invoke the processing if necessary.

--- a/docs/howto/programmatic/download.md
+++ b/docs/howto/programmatic/download.md
@@ -1,3 +1,5 @@
+# Download data
+
 A common use-case for the NOMAD API is to download large amounts of NOMAD data.
 In this how-to guide, we use curl and API endpoints
 that stream .zip files to download many resources with a single request directly from

--- a/docs/tutorial/access_api.md
+++ b/docs/tutorial/access_api.md
@@ -1,3 +1,5 @@
+# Accessing data via API
+
 !!! warning "Attention"
     We are currently working to update this content.
 

--- a/docs/tutorial/custom.md
+++ b/docs/tutorial/custom.md
@@ -1,3 +1,5 @@
+# Creating custom schemas
+
 ## What is a custom schema
 
 !!! warning "Attention"

--- a/docs/tutorial/custom.md
+++ b/docs/tutorial/custom.md
@@ -70,13 +70,13 @@ In the following sections, two examples will be illustrated. A [tabular data fil
 We want instantiate an object created from the schema already shown in the first [Tutorial section](#what-is-a-custom-schema) and populate it with the data contained in the following excel file.
 
 <p align="center" width="100%">
-    <img width="30%" src="../howto/customization/images/2col.png">
+    <img width="30%" src="../howto/customization/images/2col.png" alt="table with two columns">
 </p>
 
 The two columns in the file will be stored in a NOMAD Entry archive within two array quantities, as shown in the image below. In the case where the section to be filled is not in the root level of our schema but nested inside, it is useful to check the dedicated [How-to](../howto/customization/tabular.md#2-column-mode-current-entry-parse-to-my-path).
 
 <p align="center" width="100%">
-    <img width="100%" src="images/tabular-1.png">
+    <img width="100%" src="images/tabular-1.png" alt="column-wise parsing into quantities of the same NOMAD Entry">
 </p>
 
 The schema will be decorated by the annotations mentioned at the beginning of this section  and will look like this:
@@ -130,7 +130,7 @@ Here the tabular data file is parsed by columns, directly within the Entry where
 #### Example 2
 
 <p align="center" width="100%">
-    <img width="100%" src="images/tabular-6.png">
+    <img width="100%" src="images/tabular-6.png" alt="row-wise parsing into individual NOMAD Entry">
 </p>
 
 In this example, each row of the tabular data file will be placed in a new Entry that is an instance of a class defined in the schema. This would make sense for, say, an inventory spreadsheet where each row can be a separate entity such as a sample, a substrate, etc.

--- a/examples/data/eln/README.md
+++ b/examples/data/eln/README.md
@@ -1,3 +1,5 @@
+# Basic ELN example
+
 This is a simple example for a basic ELN. It demonstrates the use of a NOMAD schema
 to define different types of entries. Based on this schema the ELN allows you to create
 Samples, Chemicals, and Instruments. The Sample entry type also allows to define

--- a/examples/data/tabular/README.md
+++ b/examples/data/tabular/README.md
@@ -1,3 +1,5 @@
+# Demonstration for tabular data usage
+
 This upload demonstrates the use of tabular data. In this example we use an *xlsx* file in combination with a custom schema. The schema describes what columns in the excel file mean and how NOMAD is expected to parse and map the content accordingly in order to produce a **FAIR** dataset.
 
 This schema is meant as a starting point. You can download the schema file and

--- a/examples/data/theory/README.md
+++ b/examples/data/theory/README.md
@@ -1,3 +1,5 @@
+# NOMAD parsers for electronic structure codes
+
 This upload demonstrate the basic use of NOMAD's *parsers*. For many *electronic
 structure codes* (VASP, etc.), NOMAD provides parsers. You simply upload
 the *input and output files* of your simulations and NOMAD parsers are extracting


### PR DESCRIPTION


Unrelated note for myself: [Default `mkdocs` title order](https://www.mkdocs.org/user-guide/writing-your-docs/#meta-data)