### PR TITLE
Remove PR trigger for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 env:
   UV_VERSION: 0.6


### PR DESCRIPTION
revert https://github.com/FAIRmat-NFDI/nomad-docs/pull/38

This leads to PR changes being directly deployed, is this needed for a reason?