### PR TITLE
Add `grant_type` to Resource Owner Password Credentials flow example

### DIFF
--- a/docs/howto/manage/program/api.md
+++ b/docs/howto/manage/program/api.md
@@ -376,7 +376,7 @@ Most of the API operations do not require any authorization and can be freely us
 without a user or credentials. However, to upload, edit, or view your own and potentially
 unpublished data, the API needs to authenticate you.
 
-The NOMAD API uses OAuth and tokens to authenticate users. We provide simple operations
+The NOMAD API uses OAuth2 and tokens to authenticate users. We provide simple operations
 that allow you to acquire an *access token* via username and password:
 
 ```py
@@ -386,7 +386,11 @@ import requests
 
 response = requests.post(
     '{{ nomad_url() }}/v1/auth/token',
-    data={'username': os.getenv('NOMAD_USERNAME'), 'password': os.getenv('NOMAD_PASSWORD')},
+    data={
+        'username': os.getenv('NOMAD_USERNAME'),
+        'password': os.getenv('NOMAD_PASSWORD'),
+        'grant_type': 'password',
+    },
 )
 token = response.json()['access_token']
 

--- a/docs/howto/manage/program/publish_python.md
+++ b/docs/howto/manage/program/publish_python.md
@@ -27,7 +27,7 @@ def get_authentication_token(nomad_url, username, password):
     '''Get the token for accessing your NOMAD unpublished uploads remotely'''
     try:
         response = requests.get(
-            nomad_url + 'auth/token', params=dict(username=username, password=password), timeout=10)
+            nomad_url + 'auth/token', params=dict(username=username, password=password, grant_type='password'), timeout=10)
         token = response.json().get('access_token')
         if token:
             return token


### PR DESCRIPTION
Make example OAuth2 spec compiant: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth-ropc#authorization-request

<img width="494" height="127" alt="image" src="https://github.com/user-attachments/assets/c7b4c4e3-e444-4213-b749-b41329e42936" />


https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR/-/merge_requests/2741