### PR TITLE
Remove the old link for Docker file.

### DIFF
--- a/docs/howto/plugins/types/north_tools.md
+++ b/docs/howto/plugins/types/north_tools.md
@@ -124,7 +124,7 @@ and visualization.
 
 #### Dockerfile structure
 
-A Dockerfile for a Jupyter-based NORTH tool typically consists of several stages. Here, we will go through a typical Dockerfile splitting the discussion in several parts. You can find a full example of a Dockerfile for a Juypter-based NORTH tool in [our cookiecutter-nomad-plugin template](https://github.com/FAIRmat-NFDI/cookiecutter-nomad-plugin/blob/main/%7B%7Bcookiecutter.plugin_name%7D%7D/py_sources/src/north_tools/%7B%7Bcookiecutter.north_tool_name%7D%7D/Dockerfile){:target="_blank" rel="noopener"}
+A Dockerfile for a Jupyter-based NORTH tool typically consists of several stages. Here, we will go through a typical Dockerfile splitting the discussion in several parts. You can find a full example of a Dockerfile for a Juypter-based NORTH tool in [nomad-north-jupyter](https://github.com/FAIRmat-NFDI/nomad-north-jupyter/blob/main/src/nomad_north_jupyter/north_tools/my_north_tool/Dockerfile){:target="_blank" rel="noopener"}
 
 The build arguments at the top allow customization of the image:
 

--- a/docs/howto/plugins/types/north_tools.md
+++ b/docs/howto/plugins/types/north_tools.md
@@ -325,13 +325,11 @@ For published images, you may follow [semantic versioning (SemVer)](https://semv
 - **Version tags**: `v1.0.0`, `v1.2.3`, etc. - Specific releases
 - **latest tag**: Points to the most recent stable release
 - **main/develop tags**: Track the main or development branch
-- **PR tags**: `pr-123` for testing pull requests before merging
 
 GitHub Actions automatically creates:
 
 - `ghcr.io/<username>/<repo>:v1.0.0` - When you tag a release
 - `ghcr.io/<username>/<repo>:main` - On push to main branch
-- `ghcr.io/<username>/<repo>:pr-123` - For pull request #123
 - `ghcr.io/<username>/<repo>:latest` - Points to the latest tagged release
 
 ## Testing NORTH tool


### PR DESCRIPTION
Update the link of Dockerfile, as the link from the old Dockerfile does not contain all the information.