### PR TITLE
Remove `polyfill.io` 

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,5 +171,4 @@ extra_css:
   - stylesheets/extra.css
 extra_javascript:
   - create-image-sliders.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
- Modern browsers should [support ES6](https://www.geeksforgeeks.org/javascript/introduction-to-es6/) out of the box (after 2015 maybe?)
- [polyfill.io is known to be malicious after 2024](https://www.google.com/search?newwindow=1&client=firefox-b-d&hs=XffU&sca_esv=ffa6fe38ad5a2295&sxsrf=ANbL-n6ncF9uabfwfwOB7GYfcCVUWGARbQ:1770893037314&q=polyfill+io+malicious&tbm=nws&source=lnms&fbs=ADc_l-aN0CWEZBOHjofHoaMMDiKp0UJuhqwKhR0QUhF54-6jIYFfWbU_Clyew-1Wh7zkL7GXEIyGmuNECR0N8Mieh0vrKPJpO5lUVqBXbR5XgGruIWdUL_zmSb6nizhc_1gpGvp_QDUJwPYcIhdGH2n9L9Dsspsu8bfZmFmqNMH6kmHVqzXR_9c9yMb6cI1VIU4MRMQS5HtJ&sa=X&ved=2ahUKEwiqnLLT4tOSAxUGB9sEHdDiIhgQ0pQJegQIGhAB&biw=1344&bih=748&dpr=1.43)
