### PR TITLE
Update the API request according to the new API

### DIFF
--- a/docs/howto/manage/program/publish_python.md
+++ b/docs/howto/manage/program/publish_python.md
@@ -26,8 +26,8 @@ import requests
 def get_authentication_token(nomad_url, username, password):
     '''Get the token for accessing your NOMAD unpublished uploads remotely'''
     try:
-        response = requests.get(
-            nomad_url + 'auth/token', params=dict(username=username, password=password, grant_type='password'), timeout=10)
+        response = requests.post(
+            nomad_url + 'auth/token', data=dict(username=username, password=password, grant_type='password'), timeout=10)
         token = response.json().get('access_token')
         if token:
             return token


### PR DESCRIPTION
According to the new API implementation, to get an `Auth` token, one has to make a `POST` request rather than a GET.

@DanielYang59, would you please verify this change?