### PR TITLE
Improve VASP license compliance documentation

### DIFF
--- a/docs/examples/computational_data/faqs.md
+++ b/docs/examples/computational_data/faqs.md
@@ -105,7 +105,7 @@ example Oasis also has its own database. it does not appear that there is a clea
 
     The VASP license does not permit free distribution of POTCAR files. To ensure compliance, NOMAD automatically processes POTCAR files during publication: the original files are removed and replaced with `POTCAR.stripped` files containing a checksum and metadata headers (but not the proprietary pseudopotential data).
 
-    See the detailed [License Compliance for VASP](../../howto/manage/gui/upload.md#processing-files){:target="_blank" rel="noopener"} section in the upload guide for potential pitfalls.
+See the detailed [License Compliance for VASP](../../howto/manage/gui/upload.md#processing-files) section in the upload guide for potential pitfalls.
 
 ??? info "Can I upload large MD trajectories?"
     NOMAD has a file size limit of 30 GB per upload. We additionally advise users to further trim their trajectories for efficient use of the platform tools. In general, it is best to upload a representative set of trajectory frames (depending on the use case), to be findable and understandable to other researchers, and then link the entry to the full raw trajectory within your own (local) storage solution, so that it can be easily accessed upon request. Please see the relevant guides for more information: [`nomad-simulation-parsers` >> Guide to preparing Gromacs trajectories for upload to NOMAD](https://fairmat-nfdi.github.io/nomad-parser-plugins-simulation/parsers/gromacs/gromacs_about.html){:target="_blank" rel="noopener"}

--- a/docs/examples/computational_data/faqs.md
+++ b/docs/examples/computational_data/faqs.md
@@ -101,8 +101,11 @@ example Oasis also has its own database. it does not appear that there is a clea
 
 ## Preparing and Managing Raw Data
 
-??? info "What happens to the VASP POTCAR upon upload?"
-    For VASP data, NOMAD complies with the licensing of the `POTCAR` files. In agreement with [Georg Kresse](https://www.vasp.at/info/team/){:target="_blank" rel="noopener"}, NOMAD extracts the most important information of the `POTCAR` file and stores them in a stripped version called `POTCAR.stripped`. The `POTCAR` files are then automatically removed from the upload, so that you can safely publish your data.
+!!! warning "What happens to VASP POTCAR files upon upload?"
+
+    The VASP license does not permit free distribution of POTCAR files. To ensure compliance, NOMAD automatically processes POTCAR files during publication: the original files are removed and replaced with `POTCAR.stripped` files containing a checksum and metadata headers (but not the proprietary pseudopotential data).
+
+    See the detailed [License Compliance for VASP](../../howto/manage/gui/upload.md#processing-files){:target="_blank" rel="noopener"} section in the upload guide for potential pitfalls.
 
 ??? info "Can I upload large MD trajectories?"
     NOMAD has a file size limit of 30 GB per upload. We additionally advise users to further trim their trajectories for efficient use of the platform tools. In general, it is best to upload a representative set of trajectory frames (depending on the use case), to be findable and understandable to other researchers, and then link the entry to the full raw trajectory within your own (local) storage solution, so that it can be easily accessed upon request. Please see the relevant guides for more information: [`nomad-simulation-parsers` >> Guide to preparing Gromacs trajectories for upload to NOMAD](https://fairmat-nfdi.github.io/nomad-parser-plugins-simulation/parsers/gromacs/gromacs_about.html){:target="_blank" rel="noopener"}

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -36,14 +36,24 @@ However, all files that are associated to a recognized *mainfile* by being in th
 same directory are displayed as **auxiliary** files next to the entry represented
 by the **mainfile**.
 
-!!! note
-    **A note for VASP users**.
+!!! warning
+    **License Compliance for VASP**.
     On the handling of **POTCAR** files: NOMAD takes care of it; you don't
     need to worry about it. We understand that POTCAR files are not supposed to be visible to
     the public according to your VASP license. Thus, in agreement with Georg Kresse, NOMAD extracts
     the most important information of POTCAR files and stores it in the files named
     `POTCAR.stripped`. These files can be accessed and downloaded by anyone, while the original
     POTCAR files are automatically removed.
+
+    The VASP license does not permit its users to freely distribute POTCAR files, which are
+    considered copyrighted material. To comply with this license, NOMAD will, upon publication,
+    remove the POTCAR files in favor of POTCAR.stripped files, which contain checksums. This
+    safety measure is a courtesy of NOMAD, which is in place for both compressed and
+    non-compressed POTCAR files, regardless of their origin. This service is a gesture of
+    goodwill from NOMAD's side, but does not relinquish the uploader from their responsibility
+    to verify overall license compliance. We also recommend against temporarily making
+    unpublished uploads that contain licensed material public, as this will not trigger the
+    automated cleaning.
 
 ## Visibility and access
 

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -43,15 +43,18 @@ by the **mainfile**.
     files for you.
 
     Upon **publication**, NOMAD removes the original POTCAR files and replaces them with
-    `POTCAR.stripped` files. This applies regardless of extra compression.
-    The stripped files contain checksums encoding of the original POTCAR files,
-    meaning that only bit equality can be established with reference files.
-    Legally most relevant, the information cannot be reverse decrypted.
-    As such, stripped files are safe for public access.
+    `POTCAR.stripped` files. The stripped files contain a checksum of the original file
+    at the top, followed by metadata headers extracted from the original POTCAR, but not
+    the proprietary pseudopotential data. The stripped files can be accessed and downloaded
+    by anyone, while the original POTCAR files are automatically removed.
+
+    **Important:** POTCAR files **must be uncompressed** for automated stripping to work.
+    Compressed POTCAR files (e.g., `POTCAR.gz`) will not be properly processed and may be
+    entirely removed without creating stripped versions.
 
     Technical considerations:
-    - cleaning is based of the filename. For licensed POTCAR files, leave "POTCAR" somewhere in the name.
-    - cleaning only occurs upon publication. We therefore strongly recommend **against** temporarily making unpublished uploads publicly visible when they contain licensed material.
+    - Stripping is based on the filename. For licensed POTCAR files, ensure "POTCAR" appears in the filename.
+    - Stripping only occurs upon publication. We therefore strongly recommend **against** temporarily making unpublished uploads publicly visible when they contain licensed material.
 
     While NOMAD provides this service as a courtesy, **uploaders remain responsible for
     verifying overall license compliance**.

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -36,8 +36,8 @@ However, all files that are associated to a recognized *mainfile* by being in th
 same directory are displayed as **auxiliary** files next to the entry represented
 by the **mainfile**.
 
-!!! warning
-    **License Compliance for VASP**.
+!!! warning "License Compliance for VASP"
+
     The VASP license does **not** permit users to freely distribute **POTCAR** files, which are
     considered copyrighted material. To ensure compliance, NOMAD automatically handles POTCAR
     files for you.

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -48,13 +48,11 @@ by the **mainfile**.
     the proprietary pseudopotential data. The stripped files can be accessed and downloaded
     by anyone, while the original POTCAR files are automatically removed.
 
-    **Important:** POTCAR files **must be uncompressed** for automated stripping to work.
-    Compressed POTCAR files (e.g., `POTCAR.gz`) will not be properly processed and may be
-    entirely removed without creating stripped versions.
+    **Important considerations:**
 
-    Technical considerations:
-    - Stripping is based on the filename. For licensed POTCAR files, ensure "POTCAR" appears in the filename.
-    - Stripping only occurs upon publication. We therefore strongly recommend **against** temporarily making unpublished uploads publicly visible when they contain licensed material.
+    - Stripping is filename-based. Ensure "POTCAR" appears in the filename for licensed files.
+    - POTCAR files **must be uncompressed** for automated stripping to work. Compressed files (e.g., `POTCAR.gz`) will not be properly processed and may be entirely removed without creating stripped versions.
+    - Stripping only occurs upon publication. We strongly recommend **against** temporarily making unpublished uploads publicly visible when they contain licensed material.
 
     While NOMAD provides this service as a courtesy, **uploaders remain responsible for
     verifying overall license compliance**.

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -38,22 +38,22 @@ by the **mainfile**.
 
 !!! warning
     **License Compliance for VASP**.
-    On the handling of **POTCAR** files: NOMAD takes care of it; you don't
-    need to worry about it. We understand that POTCAR files are not supposed to be visible to
-    the public according to your VASP license. Thus, in agreement with Georg Kresse, NOMAD extracts
-    the most important information of POTCAR files and stores it in the files named
-    `POTCAR.stripped`. These files can be accessed and downloaded by anyone, while the original
-    POTCAR files are automatically removed.
+    The VASP license does **not** permit users to freely distribute **POTCAR** files, which are
+    considered copyrighted material. To ensure compliance, NOMAD automatically handles POTCAR
+    files for you.
 
-    The VASP license does not permit its users to freely distribute POTCAR files, which are
-    considered copyrighted material. To comply with this license, NOMAD will, upon publication,
-    remove the POTCAR files in favor of POTCAR.stripped files, which contain checksums. This
-    safety measure is a courtesy of NOMAD, which is in place for both compressed and
-    non-compressed POTCAR files, regardless of their origin. This service is a gesture of
-    goodwill from NOMAD's side, but does not relinquish the uploader from their responsibility
-    to verify overall license compliance. We also recommend against temporarily making
-    unpublished uploads that contain licensed material public, as this will not trigger the
-    automated cleaning.
+    Upon **publication**, NOMAD removes the original POTCAR files and replaces them with
+    `POTCAR.stripped` files. These stripped files contain checksums and the most important
+    metadata extracted from the original POTCAR files. The stripped files can be accessed
+    and downloaded by anyone, while the original POTCAR files are automatically removed.
+
+    This automated cleaning applies to both compressed and non-compressed POTCAR files,
+    regardless of their origin. **Beware** The cleaning only occurs upon publication.
+    We therefore strongly recommend **against** temporarily making unpublished uploads that contain
+    licensed material publicly visible.
+
+    While NOMAD provides this service as a courtesy, **uploaders remain responsible for
+    verifying overall license compliance**.
 
 ## Visibility and access
 

--- a/docs/howto/manage/gui/upload.md
+++ b/docs/howto/manage/gui/upload.md
@@ -43,14 +43,15 @@ by the **mainfile**.
     files for you.
 
     Upon **publication**, NOMAD removes the original POTCAR files and replaces them with
-    `POTCAR.stripped` files. These stripped files contain checksums and the most important
-    metadata extracted from the original POTCAR files. The stripped files can be accessed
-    and downloaded by anyone, while the original POTCAR files are automatically removed.
+    `POTCAR.stripped` files. This applies regardless of extra compression.
+    The stripped files contain checksums encoding of the original POTCAR files,
+    meaning that only bit equality can be established with reference files.
+    Legally most relevant, the information cannot be reverse decrypted.
+    As such, stripped files are safe for public access.
 
-    This automated cleaning applies to both compressed and non-compressed POTCAR files,
-    regardless of their origin. **Beware** The cleaning only occurs upon publication.
-    We therefore strongly recommend **against** temporarily making unpublished uploads that contain
-    licensed material publicly visible.
+    Technical considerations:
+    - cleaning is based of the filename. For licensed POTCAR files, leave "POTCAR" somewhere in the name.
+    - cleaning only occurs upon publication. We therefore strongly recommend **against** temporarily making unpublished uploads publicly visible when they contain licensed material.
 
     While NOMAD provides this service as a courtesy, **uploaders remain responsible for
     verifying overall license compliance**.


### PR DESCRIPTION
## Summary

Improve VASP license compliance documentation by changing the admonition from note to warning, elaborating on the POTCAR stripping process (checksum at top, followed by metadata headers, with proprietary pseudopotential data removed), and documenting critical pitfalls including that POTCAR files must be uncompressed for automated stripping to work (compressed files like `POTCAR.gz` will not be properly processed), stripping is filename-based (requiring "POTCAR" in the name), and stripping only occurs upon publication.

## Related

- References GitLab issue #2384 (POTCAR stripping and removal)
- Code implementation: `nomad/processing/data.py:2582-2627`