### PR TITLE
recover example `nomad.yaml`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,29 +9,6 @@
 *.log.conf
 parser.osio.log
 docs/*.graffle
-gui/.editorconfig
-gui/.pnp.cjs
-gui/.yarn/
-gui/.yarnrc.yml
-gui/junit.xml
-
-# Ignore all user-specific configuration files
-nomad.yaml
-gui/public/env.js
-gui/public/artifacts.js
-gui/tests/env.js
-gui/tests/artifacts.js
-!gui/tests/nomad.yaml
-!ops/docker-compose/nomad-oasis/configs/nomad.yaml
-!ops/docker-compose/nomad-oasis-with-keycloak/configs/nomad.yaml
-
-# Ignore built gui and docs artifacts
-nomad/app/static/.gui_configured
-nomad/app/static/docs
-nomad/app/static/gui
-
-nomad/normalizing/data/*.db
-nomad/normalizing/data/*.msg
 
 # Ignore default output dir for the bundle CLI commands
 bundles

--- a/docs/howto/oasis/ops/docker-compose/nomad-oasis-with-keycloak/configs/nomad.yaml
+++ b/docs/howto/oasis/ops/docker-compose/nomad-oasis-with-keycloak/configs/nomad.yaml
@@ -1,0 +1,32 @@
+services:
+  api_host: "localhost"
+  api_base_path: "/nomad-oasis"
+
+oasis:
+  is_oasis: true
+  uses_central_user_management: false
+
+north:
+  jupyterhub_crypt_key: "978bfb2e13a8448a253c629d8dd84ff89587f30e635b753153960930cad9d36d"
+
+keycloak:
+  server_url: "http://keycloak:8080/auth/"
+  public_server_url: "http://localhost/keycloak/auth/"
+  realm_name: nomad
+  username: "admin"
+  password: "password"
+
+meta:
+  deployment: "oasis"
+  deployment_url: "https://my-oasis.org/api"
+  maintainer_email: "me@my-oasis.org"
+
+logtransfer:
+  enabled: false
+
+mongo:
+  db_name: nomad_oasis_v1
+
+elastic:
+  entries_index: nomad_oasis_entries_v1
+  materials_index: nomad_oasis_materials_v1

--- a/docs/howto/oasis/ops/docker-compose/nomad-oasis/configs/nomad.yaml
+++ b/docs/howto/oasis/ops/docker-compose/nomad-oasis/configs/nomad.yaml
@@ -1,0 +1,25 @@
+services:
+  api_host: "localhost"
+  api_base_path: "/nomad-oasis"
+
+oasis:
+  is_oasis: true
+  uses_central_user_management: true
+
+north:
+  jupyterhub_crypt_key: "978bfb2e13a8448a253c629d8dd84ff89587f30e635b753153960930cad9d36d"
+
+meta:
+  deployment: "oasis"
+  deployment_url: "https://my-oasis.org/api"
+  maintainer_email: "me@my-oasis.org"
+
+logtransfer:
+  enabled: false
+
+mongo:
+  db_name: nomad_oasis_v1
+
+elastic:
+  entries_index: nomad_oasis_entries_v1
+  materials_index: nomad_oasis_materials_v1


### PR DESCRIPTION
some yaml files must be lost in https://github.com/FAIRmat-NFDI/nomad-docs/pull/213 because they were excluded by .gitignore

I checked the docs repo and don't see other `nomad.yaml` being used/lost