### PR TITLE
fix mermaid diagram in dark mode

### DIFF
--- a/docs/explanation/auth.md
+++ b/docs/explanation/auth.md
@@ -43,8 +43,8 @@ flowchart TD
     class D,E,H,J,L config
     class N success
 
-    classDef config fill:#fff5f5,stroke:#d73a49,stroke-width:2px;
-    classDef success fill:#e6ffed,stroke:#2ea44f,stroke-width:2px;
+    classDef config stroke:#d73a49,stroke-width:4px;
+    classDef success stroke:#2ea44f,stroke-width:4px;
 ```
 
 ## Access tokens


### PR DESCRIPTION
I also check other two diagrames and they're not affected (they didn't hard code the background color)

<img width="785" height="612" alt="image" src="https://github.com/user-attachments/assets/98b066b2-8d2d-44a5-a87e-73910a9570e6" />


https://fairmat-nfdi.github.io/nomad-docs/howto/manage/gui/workflows.html#simple-workflows-with-supported-tasks

<img width="560" height="213" alt="image" src="https://github.com/user-attachments/assets/f5c57130-1e63-4a37-8e76-2a361daf0609" />


https://fairmat-nfdi.github.io/nomad-docs/howto/manage/gui/workflows.html#in-a-single-entry

<img width="719" height="325" alt="image" src="https://github.com/user-attachments/assets/e4fb7dd3-5115-4c74-ac7f-f465d8f95f7c" />
