### PR TITLE
Relocate `uv self update` to standalone installer section

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you *do not* have an up-to-date Python installation (3.11 or 3.12), see [Help
 
 #### (a) Standalone
 
-##### On macOS and Linux`
+##### On macOS and Linux
 
 ```bash
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -40,6 +40,12 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+If installed via the standalone installer, `uv` can update itself to the latest version:
+
+```bash
+uv self update
 ```
 
 Or, from PyPI:
@@ -54,12 +60,6 @@ pip install uv
 
 ```bash
 pipx install uv
-```
-
-If installed via the standalone installer, uv can update itself to the latest version:
-
-```bash
-uv self update
 ```
 
 ### 2. Run the Local Docs Server


### PR DESCRIPTION
Update: didn't realize [uv docs](https://github.com/astral-sh/uv?tab=readme-ov-file#installation) also used this order (thought it was mislocated), but guess both have its reason: group by installer vs group by step (install/update), so I wouldn't move them again for now