### PR TITLE
Clarify that shape works uniformly for all quantity types

### DIFF
--- a/docs/howto/manage/gui/yaml.md
+++ b/docs/howto/manage/gui/yaml.md
@@ -119,7 +119,7 @@ Dimensions can be given as:
 - A string that describes the name of a sibling quantity with an integer type, e.g. `['number_of_atoms', 3]`
 
 !!! note
-    The `shape` attribute works identically for all quantity types, including Reference types. Whether a quantity holds primitive values (strings, numbers) or references to other sections, the shape always defines the dimensionality in the same way.
+    The `shape` attribute works identically for all quantity types, including Reference types. For Reference types, shape defines the dimensionality of the references themselves (e.g., a single reference vs. an array of references), not the shape of the referenced data.
 
 ### Unit
 

--- a/docs/howto/manage/gui/yaml.md
+++ b/docs/howto/manage/gui/yaml.md
@@ -118,6 +118,9 @@ Dimensions can be given as:
 - the string `'*'` to denote am arbitrary sized dimension, e.g. a list quantity would have shape `['*']`.
 - A string that describes the name of a sibling quantity with an integer type, e.g. `['number_of_atoms', 3]`
 
+!!! note
+    The `shape` attribute works identically for all quantity types, including Reference types. Whether a quantity holds primitive values (strings, numbers) or references to other sections, the shape always defines the dimensionality in the same way.
+
 ### Unit
 
 NOMAD manages units and data with units via the [Pint](https://pint.readthedocs.io/en/stable/){:target="_blank" rel="noopener"} Python package. A unit is given as a string that is parsed by pint. These strings can

--- a/docs/howto/plugins/types/schema_packages.md
+++ b/docs/howto/plugins/types/schema_packages.md
@@ -238,6 +238,10 @@ represents a single piece of data. Quantities can be defined with the following 
 - `shape`: defines the dimensionality of the quantity. Examples are: `[]` (number),
   `['*']` (list), `[3, 3]` (3 by 3 matrix), `['n_elements']` (a vector of length defined by
   another quantity `n_elements`).
+
+!!! note
+    The `shape` attribute works identically for all quantity types, including Reference types. Whether a quantity holds primitive values (strings, numbers) or references to other sections, the shape always defines the dimensionality in the same way.
+
 - `unit`: a physical unit. We use [Pint](https://pint.readthedocs.io/en/stable/){:target="_blank" rel="noopener"} here. You can
   use unit strings that are parsed by Pint, e.g. `meter`, `m`, `m/s^2`. As a convention the
   NOMAD Metainfo uses only SI units.

--- a/docs/howto/plugins/types/schema_packages.md
+++ b/docs/howto/plugins/types/schema_packages.md
@@ -240,7 +240,7 @@ represents a single piece of data. Quantities can be defined with the following 
   another quantity `n_elements`).
 
 !!! note
-    The `shape` attribute works identically for all quantity types, including Reference types. Whether a quantity holds primitive values (strings, numbers) or references to other sections, the shape always defines the dimensionality in the same way.
+    The `shape` attribute works identically for all quantity types, including Reference types. For Reference types, shape defines the dimensionality of the references themselves (e.g., a single reference vs. an array of references), not the shape of the referenced data.
 
 - `unit`: a physical unit. We use [Pint](https://pint.readthedocs.io/en/stable/){:target="_blank" rel="noopener"} here. You can
   use unit strings that are parsed by Pint, e.g. `meter`, `m`, `m/s^2`. As a convention the


### PR DESCRIPTION
## Summary

Adds note admonitions clarifying that the `shape` attribute works identically for all quantity types, including Reference types.

## Changes

- Added note in `docs/howto/manage/gui/yaml.md` after Shape definition
- Added note in `docs/howto/plugins/types/schema_packages.md` after shape property definition

This addresses potential confusion about whether shape behaves differently for references versus primitive types.