### PR TITLE
Improve visibility of get_plugin_entry_point function

### DIFF
--- a/docs/explanation/plugin_system.md
+++ b/docs/explanation/plugin_system.md
@@ -130,14 +130,7 @@ class MyParserEntryPoint(ParserEntryPoint):
         return MyParser(**self.dict())
 ```
 
-Often when loading the resource, you will need access to the final entry point configuration defined in `nomad.yaml`. This way also any overrides to the plugin configuration are correctly taken into account. You can get the final configuration using the `get_plugin_entry_point` function and the plugin name as defined in `pyproject.toml` as an argument:
-
-```python
-from nomad.config import config
-
-configuration = config.get_plugin_entry_point('nomad_example.parsers:myparser')
-print(f'The parser parameter is: {configuration.parameter}')
-```
+Often when loading the resource, you will need access to the final entry point configuration defined in `nomad.yaml`, including any overrides. For details on how to retrieve plugin configuration at runtime using `get_plugin_entry_point()`, see [Accessing plugin configuration at runtime](../howto/plugins/plugins.md#accessing-plugin-configuration-at-runtime).
 
 ## Entry point discovery
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -65,7 +65,7 @@ plugins:
 
 ## Accessing plugin configuration at runtime
 
-When developing plugins, you can access both the plugin's configuration (metadata and parameters) and the actual plugin implementation (the resource). NOMAD uses a [lazy-loading pattern](../../explanation/plugin_system.md#plugin-resource) where these are kept separate: `get_plugin_entry_point()` returns the entry point configuration, while `.load()` returns the actual plugin resource.
+When developing plugins, you can access both the plugin's configuration (metadata and parameters) and the actual plugin implementation (the resource). NOMAD uses a [lazy-loading pattern](../../explanation/plugin_system.md#plugin-resource) where these are kept separate: `get_plugin_entry_point()` returns the entry point configuration, while `EntryPoint.load()` returns the actual plugin resource.
 
 ### Configuring plugin parameters
 
@@ -105,9 +105,9 @@ print(f'Plugin name: {entry_point.name}')
 
 The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.
 
-### Loading the plugin resource with `.load()`
+### Loading the plugin resource with `EntryPoint.load()`
 
-If you need to access the actual plugin implementation (not just its configuration), call the `.load()` method on the entry point. This returns the plugin resource, such as a Parser instance, Normalizer, FastAPI app, or SchemaPackage.
+Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call its `.load()` method to access the actual plugin implementation. This returns the plugin resource, such as a Parser instance, Normalizer, FastAPI app, or SchemaPackage.
 
 ```python
 from nomad.config import config
@@ -122,7 +122,7 @@ parser = entry_point.load()
 parser.parse('path/to/file.out', archive, logger)
 ```
 
-The resource is only loaded when you call `.load()`, not when you call `get_plugin_entry_point()`. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
+Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `.load()` on that entry point to get the resource. The resource is only loaded when you call `.load()`, not during the initial `get_plugin_entry_point()` call. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
 
 ### Additional resources
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -86,6 +86,8 @@ For comprehensive documentation on plugin configuration options, see the [Config
 
 To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This returns your plugin's entry point configuration with all administrator overrides applied, giving you access to custom parameters and metadata (such as plugin name and description) while ensuring all settings are up-to-date.
 
+**When to use this:** Use `get_plugin_entry_point()` when your plugin logic needs to access configuration parameters, such as when passing a configuration value to internal plugin functions or when retrieving metadata.
+
 ```python
 from nomad.config import config
 
@@ -104,7 +106,9 @@ The entry point name passed to `get_plugin_entry_point()` must match the name de
 
 ### Loading the plugin resource with `EntryPoint.load()`
 
-Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call `EntryPoint.load()` to access the actual plugin implementation. This returns the plugin resource, such as a `Parser` instance, `Normalizer`, `FastAPI` app, or `SchemaPackage`.
+Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call `EntryPoint.load()` to access the actual plugin implementation. This returns the plugin resource, such as a `Parser` instance, `Normalizer`, `FastAPI` app, or `SchemaPackage`. Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `EntryPoint.load()` on that entry point to get the resource.
+
+NOMAD automatically loads plugin resources when it needs them (e.g., when parsing a file). You typically only need to manually call `EntryPoint.load()` when writing plugin code that needs to access another plugin's resource. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
 
 ```python
 from nomad.config import config
@@ -115,8 +119,6 @@ parser = entry_point.load()
 # Use the parser instance
 parser.parse('path/to/file.out', archive, logger)
 ```
-
-Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `EntryPoint.load()` on that entry point to get the resource. The resource is only loaded when you call `EntryPoint.load()`, not during the initial `get_plugin_entry_point()` call. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
 
 ### Additional resources
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -84,7 +84,7 @@ For comprehensive documentation on plugin configuration options, see the [Config
 
 ### Retrieving configuration with `get_plugin_entry_point()`
 
-To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This function returns the final entry point configuration with all administrator overrides applied, ensuring that the settings are up-to-date and all default overrides are included.
+To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This returns your plugin's entry point configuration with all administrator overrides applied, giving you access to custom parameters and metadata (such as plugin name and description) while ensuring all settings are up-to-date.
 
 ```python
 from nomad.config import config
@@ -104,13 +104,6 @@ print(f'Plugin name: {entry_point.name}')
 ```
 
 The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.
-
-**When to use this:**
-
-- Accessing custom configuration parameters defined in your entry point class
-- Retrieving metadata about your plugin (name, description, etc.)
-- Getting configuration values that may have been overridden by administrators
-- Accessing any property defined in your entry point's pydantic model
 
 ### Understanding the lazy-loading pattern
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -84,7 +84,7 @@ For comprehensive documentation on plugin configuration options, see the [Config
 
 ### Retrieving configuration with `get_plugin_entry_point()`
 
-To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This function returns the final entry point configuration with all administrator overrides applied.
+To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This function returns the final entry point configuration with all administrator overrides applied, ensuring that the settings are up-to-date and all default overrides are included.
 
 ```python
 from nomad.config import config

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -84,9 +84,7 @@ For comprehensive documentation on plugin configuration options, see the [Config
 
 ### Retrieving configuration with `get_plugin_entry_point()`
 
-To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This returns your plugin's entry point configuration with all administrator overrides applied, giving you access to custom parameters and metadata (such as plugin name and description) while ensuring all settings are up-to-date.
-
-**When to use this:** Use `get_plugin_entry_point()` when your plugin logic needs to access configuration parameters, such as when passing a configuration value to internal plugin functions or when retrieving metadata.
+To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This returns your plugin's entry point configuration with all administrator overrides applied, giving you access to custom parameters and other relevant configurations, while ensuring all settings are up-to-date.
 
 ```python
 from nomad.config import config
@@ -97,28 +95,9 @@ entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
 # Access configuration parameters
 print(f'Parameter value: {entry_point.parameter}')  # Output: Parameter value: custom_value
 print(f'Another setting: {entry_point.another_setting}')  # Output: Another setting: 42
-
-# Access metadata
-print(f'Plugin name: {entry_point.name}')  # Output: Plugin name: nomad_example.parsers:myparser
 ```
 
 The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']` (the same name used when configuring the plugin in `nomad.yaml`).
-
-### Loading the plugin resource with `EntryPoint.load()`
-
-Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call `EntryPoint.load()` to access the actual plugin implementation. This returns the plugin resource, such as a `Parser` instance, `Normalizer`, `FastAPI` app, or `SchemaPackage`. Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `EntryPoint.load()` on that entry point to get the resource.
-
-NOMAD automatically loads plugin resources when it needs them (e.g., when parsing a file). You typically only need to manually call `EntryPoint.load()` when writing plugin code that needs to access another plugin's resource. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
-
-```python
-from nomad.config import config
-
-entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
-parser = entry_point.load()
-
-# Use the parser instance
-parser.parse('path/to/file.out', archive, logger)
-```
 
 ### Additional resources
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -63,6 +63,71 @@ plugins:
     exclude: ["nomad_plugin.parsers:myparser"]
 ```
 
+## Accessing plugin configuration at runtime
+
+When developing plugins, your code often needs to access configuration parameters that administrators define in `nomad.yaml`. This is especially important when configuration values can be overridden by users of your plugin.
+
+### Configuring plugin parameters
+
+Administrators can override plugin-specific parameters using the `plugins.entry_points.options` section in `nomad.yaml`. For example:
+
+```yaml
+plugins:
+  entry_points:
+    options:
+      nomad_example.parsers:myparser:
+        parameter: "custom_value"
+        another_setting: 42
+```
+
+For comprehensive documentation on plugin configuration options, see the [Configuration reference](../../reference/config.md).
+
+### Retrieving configuration with `get_plugin_entry_point()`
+
+To access your plugin's configuration from within your plugin code, use the `get_plugin_entry_point()` function from `nomad.config`. This function returns the final entry point configuration with all administrator overrides applied.
+
+```python
+from nomad.config import config
+
+# Get your plugin's entry point configuration
+entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
+
+# Access configuration parameters
+print(f'Parameter value: {entry_point.parameter}')
+print(f'Another setting: {entry_point.another_setting}')
+```
+
+The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.
+
+**When to use this:**
+
+- Accessing custom configuration parameters defined in your entry point class
+- Retrieving metadata about your plugin (name, description, etc.)
+- Getting configuration values that may have been overridden by administrators
+- Accessing any property defined in your entry point's pydantic model
+
+### Understanding the lazy-loading pattern
+
+NOMAD uses a lazy-loading pattern for plugins, where the entry point (configuration) is separate from the resource (the actual implementation). The entry point is loaded immediately when NOMAD starts, while the resource (e.g., your parser class, normalizer, or API) is only loaded when needed.
+
+This separation allows NOMAD to:
+
+- Load plugin metadata and configuration quickly at startup
+- Defer loading heavy resources until they're actually used
+- Validate configuration without importing all plugin code
+
+When you call `get_plugin_entry_point()`, you're accessing the entry point configuration. To load the actual plugin resource, NOMAD internally calls the entry point's `load()` method. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
+
+### Additional resources
+
+- [Plugin entry point models reference](../../reference/plugins.md) - Documentation for all entry point types
+- [NOMAD plugin system explanation](../../explanation/plugin_system.md) - Conceptual overview of the plugin architecture
+- Plugin type-specific guides for examples:
+    - [Parsers](./types/parsers.md)
+    - [APIs](./types/apis.md)
+    - [Normalizers](./types/normalizers.md)
+    - [Schema packages](./types/schema_packages.md)
+
 ## Plugin development guidelines
 
 ### Linting and formatting

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -65,7 +65,7 @@ plugins:
 
 ## Accessing plugin configuration at runtime
 
-When developing plugins, your code often needs to access configuration parameters that administrators define in `nomad.yaml`. This is especially important when configuration values can be overridden by users of your plugin.
+When developing plugins, you can access both the plugin's configuration (metadata and parameters) and the actual plugin implementation (the resource). NOMAD uses a [lazy-loading pattern](../../explanation/plugin_system.md#plugin-resource) where these are kept separate: `get_plugin_entry_point()` returns the entry point configuration, while `.load()` returns the actual plugin resource.
 
 ### Configuring plugin parameters
 
@@ -105,17 +105,24 @@ print(f'Plugin name: {entry_point.name}')
 
 The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.
 
-### Understanding the lazy-loading pattern
+### Loading the plugin resource with `.load()`
 
-NOMAD uses a lazy-loading pattern for plugins, where the entry point (configuration) is separate from the resource (the actual implementation). The entry point is loaded immediately when NOMAD starts, while the resource (e.g., your parser class, normalizer, or API) is only loaded when needed.
+If you need to access the actual plugin implementation (not just its configuration), call the `.load()` method on the entry point. This returns the plugin resource, such as a Parser instance, Normalizer, FastAPI app, or SchemaPackage.
 
-This separation allows NOMAD to:
+```python
+from nomad.config import config
 
-- Load plugin metadata and configuration quickly at startup
-- Defer loading heavy resources until they're actually used
-- Validate configuration without importing all plugin code
+# Get the entry point
+entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
 
-When you call `get_plugin_entry_point()`, you're accessing the entry point configuration. To load the actual plugin resource, NOMAD internally calls the entry point's `load()` method. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
+# Load the actual parser resource
+parser = entry_point.load()
+
+# Now you can use the parser instance
+parser.parse('path/to/file.out', archive, logger)
+```
+
+The resource is only loaded when you call `.load()`, not when you call `get_plugin_entry_point()`. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
 
 ### Additional resources
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -93,36 +93,30 @@ from nomad.config import config
 entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
 
 # Access configuration parameters
-print(f'Parameter value: {entry_point.parameter}')
-# Output: Parameter value: custom_value
-print(f'Another setting: {entry_point.another_setting}')
-# Output: Another setting: 42
+print(f'Parameter value: {entry_point.parameter}')  # Output: Parameter value: custom_value
+print(f'Another setting: {entry_point.another_setting}')  # Output: Another setting: 42
 
 # Access metadata
-print(f'Plugin name: {entry_point.name}')
-# Output: Plugin name: nomad_example.parsers:myparser
+print(f'Plugin name: {entry_point.name}')  # Output: Plugin name: nomad_example.parsers:myparser
 ```
 
-The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.
+The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']` (the same name used when configuring the plugin in `nomad.yaml`).
 
 ### Loading the plugin resource with `EntryPoint.load()`
 
-Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call its `.load()` method to access the actual plugin implementation. This returns the plugin resource, such as a Parser instance, Normalizer, FastAPI app, or SchemaPackage.
+Once you have retrieved the entry point using `get_plugin_entry_point()`, you can call `EntryPoint.load()` to access the actual plugin implementation. This returns the plugin resource, such as a `Parser` instance, `Normalizer`, `FastAPI` app, or `SchemaPackage`.
 
 ```python
 from nomad.config import config
 
-# Get the entry point
 entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
-
-# Load the actual parser resource
 parser = entry_point.load()
 
-# Now you can use the parser instance
+# Use the parser instance
 parser.parse('path/to/file.out', archive, logger)
 ```
 
-Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `.load()` on that entry point to get the resource. The resource is only loaded when you call `.load()`, not during the initial `get_plugin_entry_point()` call. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
+Note that you must first call `get_plugin_entry_point()` to retrieve the entry point, then call `EntryPoint.load()` on that entry point to get the resource. The resource is only loaded when you call `EntryPoint.load()`, not during the initial `get_plugin_entry_point()` call. This lazy-loading pattern improves startup performance by deferring heavy resource initialization until actually needed. For more details on the plugin system architecture, see the [NOMAD plugin system](../../explanation/plugin_system.md) documentation.
 
 ### Additional resources
 

--- a/docs/howto/plugins/plugins.md
+++ b/docs/howto/plugins/plugins.md
@@ -94,7 +94,13 @@ entry_point = config.get_plugin_entry_point('nomad_example.parsers:myparser')
 
 # Access configuration parameters
 print(f'Parameter value: {entry_point.parameter}')
+# Output: Parameter value: custom_value
 print(f'Another setting: {entry_point.another_setting}')
+# Output: Another setting: 42
+
+# Access metadata
+print(f'Plugin name: {entry_point.name}')
+# Output: Plugin name: nomad_example.parsers:myparser
 ```
 
 The entry point name passed to `get_plugin_entry_point()` must match the name defined in your plugin's `pyproject.toml` under `[project.entry-points.'nomad.plugin']`.


### PR DESCRIPTION
Adds a new section 'Accessing plugin configuration at runtime' to the plugin development guide, documenting how to use `get_plugin_entry_point()` to retrieve plugin configuration, the lazy-loading pattern, and when to use this function. This addresses the low discoverability of this important function which was previously only mentioned briefly in scattered locations.