### PR TITLE
Stabilize docs validation by building MkDocs output during tests and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ uv run mkdocs build --strict
 uv run --group dev pytest -q
 ```
 
-Temporary note for the current refactoring project: when you touch deployment-specific content, add an HTML comment near the top of the page to label scope without changing rendered output, for example `<!-- doc-scope: deployment-specific; target=oasis -->`.
+### Temporary refactoring note
+
+For the current refactoring project, when you touch deployment-specific content, add an HTML comment near the top of the page to label scope without changing rendered output, for example `<!-- doc-scope: deployment-specific; target=oasis -->`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ uv run mkdocs build --strict
 uv run --group dev pytest -q
 ```
 
-### Temporary refactoring note
-
-For the current refactoring project, when you touch deployment-specific content, add an HTML comment near the top of the page to label scope without changing rendered output, for example `<!-- doc-scope: deployment-specific; target=oasis -->`.
-
 ---
 
 ## Automated Tests

--- a/README.md
+++ b/README.md
@@ -81,16 +81,7 @@ uv run mkdocs build --strict
 uv run --group dev pytest -q
 ```
 
-For a quick task-branch baseline check, run:
-
-```bash
-git fetch origin --prune
-git switch develop
-git pull --ff-only origin develop
-git switch -c docs/<task-name>
-uv run mkdocs build --strict
-uv run --group dev pytest -q
-```
+Temporary note for the current refactoring project: when you touch deployment-specific content, add an HTML comment near the top of the page to label scope without changing rendered output, for example `<!-- doc-scope: deployment-specific; target=oasis -->`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ This will install all requirements in a virtual environment and start the local 
 ### How to run the tests
 
 ```bash
-uv run --extra dev pytest
+uv run mkdocs build --strict
+uv run --group dev pytest -q
+```
+
+For a quick task-branch baseline check, run:
+
+```bash
+git fetch origin --prune
+git switch develop
+git pull --ff-only origin develop
+git switch -c docs/<task-name>
+uv run mkdocs build --strict
+uv run --group dev pytest -q
 ```
 
 ---

--- a/docs/writing_guide.md
+++ b/docs/writing_guide.md
@@ -25,45 +25,6 @@ When contributing, identify which type of documentation your addition belongs to
 - **Keep essential context in place, centralize reusable content.** Provide enough information directly on the page so the user can follow without friction. For reused, larger blocks of content, keep a single authoritative version and link to it.
 - **Check accuracy with the actual system.** Verify commands, screenshots, and examples against the current NOMAD deployment. *Only merge a docs PR after the corresponding code changes have been merged into `nomad-lab`’s `develop` branch*.
 
-## Validation Before PR
-
-Every docs PR should pass the local validation baseline before review:
-
-```bash
-uv run mkdocs build --strict
-uv run --group dev pytest -q
-```
-
-At minimum, contributors should verify:
-
-- The docs build completes without strict-mode failures.
-- The test suite passes.
-- New or moved pages are reachable from navigation when intended.
-- Internal and external links follow the rules in this guide.
-
-For task-wise work, prefer a fresh branch from `develop`:
-
-```bash
-git fetch origin --prune
-git switch develop
-git pull --ff-only origin develop
-git switch -c docs/<task-name>
-```
-
-## Documentation Scope Markers
-
-When a page is clearly deployment-specific rather than general-purpose NOMAD documentation, add an invisible source marker near the top of the file. Use HTML comments so this first-pass labeling does not affect rendering.
-
-Examples:
-
-```html
-<!-- doc-scope: deployment-specific; target=oasis -->
-<!-- doc-scope: deployment-specific; target=plugin -->
-<!-- doc-scope: deployment-specific; target=central -->
-```
-
-Use these markers consistently, but do not reorganize navigation around them unless the task explicitly includes that refactor.
-
 ## Styling & Conventions
 
 ### Headings & Structure

--- a/docs/writing_guide.md
+++ b/docs/writing_guide.md
@@ -25,6 +25,45 @@ When contributing, identify which type of documentation your addition belongs to
 - **Keep essential context in place, centralize reusable content.** Provide enough information directly on the page so the user can follow without friction. For reused, larger blocks of content, keep a single authoritative version and link to it.
 - **Check accuracy with the actual system.** Verify commands, screenshots, and examples against the current NOMAD deployment. *Only merge a docs PR after the corresponding code changes have been merged into `nomad-lab`’s `develop` branch*.
 
+## Validation Before PR
+
+Every docs PR should pass the local validation baseline before review:
+
+```bash
+uv run mkdocs build --strict
+uv run --group dev pytest -q
+```
+
+At minimum, contributors should verify:
+
+- The docs build completes without strict-mode failures.
+- The test suite passes.
+- New or moved pages are reachable from navigation when intended.
+- Internal and external links follow the rules in this guide.
+
+For task-wise work, prefer a fresh branch from `develop`:
+
+```bash
+git fetch origin --prune
+git switch develop
+git pull --ff-only origin develop
+git switch -c docs/<task-name>
+```
+
+## Documentation Scope Markers
+
+When a page is clearly deployment-specific rather than general-purpose NOMAD documentation, add an invisible source marker near the top of the file. Use HTML comments so this first-pass labeling does not affect rendering.
+
+Examples:
+
+```html
+<!-- doc-scope: deployment-specific; target=oasis -->
+<!-- doc-scope: deployment-specific; target=plugin -->
+<!-- doc-scope: deployment-specific; target=central -->
+```
+
+Use these markers consistently, but do not reorganize navigation around them unless the task explicitly includes that refactor.
+
 ## Styling & Conventions
 
 ### Headings & Structure

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,11 +1,44 @@
+import subprocess
+import sys
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 from nomad.app.main import app
+from nomad.app.static import app as static_app
 from nomad.config import config
 
 
 @pytest.fixture(scope="session")
-def client():
+def built_docs_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    repo_root = Path(__file__).resolve().parent.parent
+    site_dir = tmp_path_factory.mktemp("site")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mkdocs",
+            "build",
+            "--strict",
+            "--site-dir",
+            str(site_dir),
+        ],
+        cwd=repo_root,
+        check=True,
+    )
+    return site_dir
+
+
+@pytest.fixture(scope="session")
+def client(built_docs_dir: Path):
+    docs_mount = next(
+        route.app
+        for route in static_app.routes
+        if getattr(route, "path", None) == "/docs"
+        and hasattr(route.app, "directory")
+    )
+    docs_mount.directory = str(built_docs_dir)
+    docs_mount.all_directories = [str(built_docs_dir)]
     return TestClient(app, base_url="http://testserver/")
 
 


### PR DESCRIPTION
This PR restores the documentation validation baseline.

It fixes tests/test_docs.py so the docs-serving test builds the current MkDocs site instead of relying on prepackaged static docs. 

It also corrects the README test command from uv run --extra dev pytest to uv run --group dev pytest -q, since dev is configured as a dependency group in this repo, not an optional extra.