### PR TITLE
Linkinspector ignore github signup page which gives 403

### DIFF
--- a/.github/workflows/configs/.linkspector.yml
+++ b/.github/workflows/configs/.linkspector.yml
@@ -19,3 +19,5 @@ ignorePatterns:
   - pattern: "^https://(www\\.)?xfce\\.org/?$"
   # hifis.net is consistently unreachable in CI (navigation times out)
   - pattern: "^https://(www\\.)?hifis\\.net/"
+  # GitHub signup is protected against automated requests and returns 403
+  - pattern: "^https://github\\.com/signup/?$"


### PR DESCRIPTION
```
>>> curl -I https://github.com/signup
HTTP/2 403
content-type: text/html
content-length: 770
x-frame-options: DENY
x-datadome: protected
accept-ch: Sec-CH-UA,Sec-CH-UA-Mobile,Sec-CH-UA-Platform,Sec-CH-UA-Arch,Sec-CH-UA-Full-Version-List,Sec-CH-UA-Model,Sec-CH-Device-Memory
content-type: text/html;charset=utf-8
charset: utf-8
cache-control: max-age=0, private, no-cache, no-store, must-revalidate
pragma: no-cache
access-control-allow-credentials: true
access-control-expose-headers: x-dd-b, x-set-cookie
access-control-allow-origin: *
x-datadome-cid: AHrlqAAAAAMApetJMZVHVBsAmDVvgw==
x-dd-b: 1
strict-transport-security: max-age=31536000; includeSubDomains; preload
date: Fri, 17 Jul 2026 06:56:09 GMT
```