### PR TITLE
Fix nomad_url() emitting localhost URLs in published docs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -22,6 +22,16 @@ jobs:
           version: ${{ env.UV_VERSION }}
 
       - name: Build and Deploy
+        # Point the `nomad_url()` macro at the central production instance so the
+        # published docs render real URLs (https://nomad-lab.eu/prod/v1/api/...).
+        # Without these, the macro falls back to the Oasis default
+        # (http://localhost:8000/nomad-oasis/...). Local and Oasis builds that
+        # do not set these keep the default behaviour.
+        env:
+          NOMAD_SERVICES_API_HOST: nomad-lab.eu
+          NOMAD_SERVICES_API_PORT: "443"
+          NOMAD_SERVICES_API_BASE_PATH: /prod/v1
+          NOMAD_SERVICES_HTTPS: "true"
         run: |
           uv run \
             --with 'nomad-lab[dev,infrastructure] @ https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git' \

--- a/.github/workflows/test-build-lint-preview.yml
+++ b/.github/workflows/test-build-lint-preview.yml
@@ -66,18 +66,14 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Check mkdocs build
-        run: |
-          uv run \
-            --with 'nomad-lab[infrastructure] @ https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git' \
-            mkdocs build --strict
-
-      - name: Check production build has no localhost URLs
         # The `nomad_url()` macro renders relative to the configured instance.
-        # The production deploy sets these env vars so docs point at
-        # https://nomad-lab.eu/prod/v1/api/... (see deploy-docs.yml). Build with
-        # the same config and fail if the Oasis default (localhost/nomad-oasis)
-        # leaks into the published output. `.linkspector` intentionally ignores
-        # localhost, so it cannot catch this class of regression.
+        # Set the same env vars as the production deploy (see deploy-docs.yml) so
+        # `site/` points at https://nomad-lab.eu/prod/v1/api/... — this is the
+        # directory that is copied into the nomad package and published as the PR
+        # preview below, so it must be built with the production config. Then fail
+        # if the Oasis default (localhost/nomad-oasis) leaks into the output.
+        # `.linkspector` intentionally ignores localhost, so it cannot catch this
+        # class of regression.
         env:
           NOMAD_SERVICES_API_HOST: nomad-lab.eu
           NOMAD_SERVICES_API_PORT: "443"
@@ -86,15 +82,14 @@ jobs:
         run: |
           uv run \
             --with 'nomad-lab[infrastructure] @ https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git' \
-            mkdocs build --strict --site-dir site-prod
+            mkdocs build --strict
           # Match the exact string the misconfigured macro emits. A bare
           # "localhost"/"nomad-oasis" grep would flag legitimate Oasis docs
           # (nginx/docker-compose configs, Oasis curl examples).
-          if grep -rniE 'localhost:8000/nomad-oasis/api' site-prod; then
+          if grep -rniE 'localhost:8000/nomad-oasis/api' site; then
             echo "::error::Oasis default URL leaked from nomad_url() into the production docs build (expected https://nomad-lab.eu/prod/v1/api/...)."
             exit 1
           fi
-          rm -rf site-prod
 
       - name: Copy built docs
         run: |

--- a/.github/workflows/test-build-lint-preview.yml
+++ b/.github/workflows/test-build-lint-preview.yml
@@ -71,6 +71,31 @@ jobs:
             --with 'nomad-lab[infrastructure] @ https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git' \
             mkdocs build --strict
 
+      - name: Check production build has no localhost URLs
+        # The `nomad_url()` macro renders relative to the configured instance.
+        # The production deploy sets these env vars so docs point at
+        # https://nomad-lab.eu/prod/v1/api/... (see deploy-docs.yml). Build with
+        # the same config and fail if the Oasis default (localhost/nomad-oasis)
+        # leaks into the published output. `.linkspector` intentionally ignores
+        # localhost, so it cannot catch this class of regression.
+        env:
+          NOMAD_SERVICES_API_HOST: nomad-lab.eu
+          NOMAD_SERVICES_API_PORT: "443"
+          NOMAD_SERVICES_API_BASE_PATH: /prod/v1
+          NOMAD_SERVICES_HTTPS: "true"
+        run: |
+          uv run \
+            --with 'nomad-lab[infrastructure] @ https://gitlab.mpcdf.mpg.de/nomad-lab/nomad-FAIR.git' \
+            mkdocs build --strict --site-dir site-prod
+          # Match the exact string the misconfigured macro emits. A bare
+          # "localhost"/"nomad-oasis" grep would flag legitimate Oasis docs
+          # (nginx/docker-compose configs, Oasis curl examples).
+          if grep -rniE 'localhost:8000/nomad-oasis/api' site-prod; then
+            echo "::error::Oasis default URL leaked from nomad_url() into the production docs build (expected https://nomad-lab.eu/prod/v1/api/...)."
+            exit 1
+          fi
+          rm -rf site-prod
+
       - name: Copy built docs
         run: |
           SITE_PACKAGES_DIR=$(uv run python -c "import sysconfig; print(sysconfig.get_paths()['purelib'])")

--- a/docs/howto/manage/program/api.md
+++ b/docs/howto/manage/program/api.md
@@ -16,7 +16,7 @@ accessed, downloaded, searched for, etc. via
 [HTTP requests](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol){:target="_blank" rel="noopener"}.
 
 You can get an overview on all NOMAD APIs on the
-[API page]({{ nomad_url() }}../../gui/analyze/apis). We will focus here on NOMAD's main
+[API page]({{ nomad_url() }}/../gui/analyze/apis). We will focus here on NOMAD's main
 API (v1). In fact, this API is also used by the web interface and should provide
 everything you need.
 


### PR DESCRIPTION
Set the instance config (`NOMAD_SERVICES_*` env) in the deploy build so the macro renders `https://nomad-lab.eu/prod/v1/api/...`. The macro is unchanged, so local/Oasis builds still produce their own URL. This fixes a
incorrectly generated link on the API page, plus adds a CI guard that fails if a localhost URL leaks.

This changes the build config, not the already-published HTML mkdocs page, so the live docs update only on the next deploy build.

