### PR TITLE
Skip PR preview deployment for fork pull requests

### DIFF
--- a/.github/workflows/test-build-lint-preview.yml
+++ b/.github/workflows/test-build-lint-preview.yml
@@ -83,7 +83,9 @@ jobs:
           uv run pytest tests
 
       - name: Deploy PR Preview
-        if: github.event_name == 'pull_request'
+        # pr-preview-action does not support fork PRs: GITHUB_TOKEN is read-only
+        # there, so the gh-pages push fails. Fork PRs still run build and tests.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: rossjrw/pr-preview-action@v1
         with:
           source-dir: site


### PR DESCRIPTION
## Problem

The `Deploy PR Preview` step (rossjrw/pr-preview-action) fails on PRs from forks: `GITHUB_TOKEN` is read-only for fork pull requests, so pushing to `gh-pages` fails and the whole `test-docs` job goes red. The action's README confirms it does not support fork PRs.

## Change

Gate the preview step to same-repo PRs only:

```yaml
if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs still run the full build, tests and lint checks — only the preview deployment is skipped.